### PR TITLE
update systemd setup script. add fast and no-reboot setup script options

### DIFF
--- a/scripts/python_dep.sh
+++ b/scripts/python_dep.sh
@@ -5,27 +5,36 @@
 # our Flask backend server. Mostly from this tutorial: 
 # https://www.codementor.io/@dongido/how-to-build-restful-apis-with-python-and-flask-12qto530jd
 
-echo ""
-echo ""
 echo "Installing Python Dependencies..."
 echo "This may take a few moments..."
-echo ""
+
+FAST=0
+for arg do
+  if [ $arg -eq 1 ]
+  then
+    FAST=1
+  fi
+done
+
 
 #Use Python 3.7 on board, not using Python2
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 7
 
-#Install Pip (If Necessary)
-sudo apt install python3-pip
-pip3 --version
-echo " - Installed pip3"
+if [ $FAST -eq 0 ]
+  then
+  #Install Pip (If Necessary)
+  sudo apt install python3-pip
+  pip3 --version
+  echo " - Installed pip3"
 
-#Flask RESTful backend dependencies
-pip3 install flask==0.12.2
-pip3 install flask_restful==0.3.6
-pip3 install flask_script==2.0.6
-pip3 install marshmallow==2.14.0
-pip3 install flask_marshmallow==0.8.0
-echo " - Installed Python dependencies"
+  #Flask RESTful backend dependencies
+  pip3 install flask==0.12.2
+  pip3 install flask_restful==0.3.6
+  pip3 install flask_script==2.0.6
+  pip3 install marshmallow==2.14.0
+  pip3 install flask_marshmallow==0.8.0
+  echo " - Installed Python dependencies"
+fi
 
 #Install Virtual Env. to create isolated Python Env.
 #WE DO NOT NEED A VIRTUAL ENVIRONMENT FOR OUR SENIOR DESIGN PROGRESS
@@ -37,7 +46,5 @@ echo " - Installed Python dependencies"
 # echo " - Virtual Environment Created"
 
 #Update user how to run server
-echo ""
-echo ""
-echo "COMPLETED Flask Backend Install script."
+echo "COMPLETED: python modules installed successfully."
 

--- a/scripts/systemd-setup.sh
+++ b/scripts/systemd-setup.sh
@@ -2,3 +2,5 @@
 
 cp files/systemd/service/hobby_hub_entry.service /etc/systemd/system
 #ln -s /lib/systemd/system/hobby_hub_entry.service /etc/systemd/system/multi-user.target.wants/hobby_hub_entry.service
+systemctl enable hobby_hub_entry.service
+systemctl daemon-reload

--- a/scripts/web-setup.sh
+++ b/scripts/web-setup.sh
@@ -5,12 +5,10 @@
 # our Flask backend server. Mostly from this tutorial: 
 # https://www.codementor.io/@dongido/how-to-build-restful-apis-with-python-and-flask-12qto530jd
 
-echo ""
-echo ""
-echo "Running Flask Backend Install script."
-echo "This may take a few moments..."
-echo ""
+echo "Installing web server."
 
 #Copy directory to our folder on board
 cp -r files/web /etc/hobby-hub/
+
+echo "Web server installed!"
 

--- a/setup.sh
+++ b/setup.sh
@@ -3,18 +3,59 @@
 # Author : 
 # Description :
 
+# flag to denote if you want fast setup
+FAST=0
+# flag to denote if you want to reboot or not.
+REBOOT=1
+# flag to display help menu
+HELP=0
+
+for arg do
+
+  if [ $arg = "fast" ]
+  then
+    FAST=1
+  fi
+
+  if [ $arg = "no-reboot" ]
+  then
+    REBOOT=0
+  fi
+
+  if [ $arg = "help" ]
+  then
+    HELP=1
+  fi
+
+  if [ $arg = "h" ]
+  then
+    HELP=1
+  fi
+
+done
+
+if [ $HELP -eq 1 ]
+then
+  echo "setup script for the hobby-hub device."
+  echo "no-reboot option does not reboot the device upon completion"
+  echo "fast option skips remote device module update"
+else 
+
 echo ""
 echo ""
 echo "Running hobby-hub setup script."
 echo "This may take a few moments..."
 echo""
 
-echo "||||||||||||||||||||||||||||||||"
-echo "||| updating device packages |||"
-echo "||||||||||||||||||||||||||||||||"
-echo ""
-sudo apt-get update
-sudo apt-get upgrade
+if [ $FAST -eq 0 ]
+then
+  echo "||||||||||||||||||||||||||||||||"
+  echo "||| updating device packages |||"
+  echo "||||||||||||||||||||||||||||||||"
+  echo ""
+  sudo apt-get update
+  sudo apt-get upgrade
+fi
 
 mkdir -p /etc/hobby-hub/
 
@@ -25,8 +66,13 @@ echo "||||||||||||||||||||||||||||||||"
 echo""
 for f in scripts/*.sh
 do
-  echo "$f"
-  sh $f
+  printf '%s\n' "[Processing sub-script: $f]"
+  if [ $FAST -eq 0 ]
+  then
+    sh $f
+  else
+    sh $f $FAST
+  fi
 done
 echo"" 
 
@@ -37,4 +83,10 @@ echo "||||||||||||||||||||||||||||||||"
 echo ""
 sleep 3
 
-#sudo reboot
+if [ $REBOOT -eq 1 ]
+then
+  sudo reboot
+fi
+
+fi # help menu
+


### PR DESCRIPTION
<!-- Ensure the Pull Request name is descriptive and accurate -->

# Date
<!-- today's date -->
Initial PR Date: 12-14-20
<!-- when does this pr need to be merged in by? (if applicable) -->
Due Date: 12-16-20

# Reviewers
<!--
These developers must review the PR before it can be mereged.
use @mention
-->

@anthony-bartman 
@rockboynton 

# Description
<!-- 
- The developer provides a detailed description of what was added and why.
- How does the proposed changes address the issue?
-->

While debugging the web server with Anthony, we noticed that the systemd service was not fully setup. upon executing the following commands (which are now added to the systemd setup script) we got it to update correctly.

Additionally, Anthony proposed a good idea to add options to the script to skip some of the module update steps. I have now added the options `fast`, `no-reboot` and `h` or `help` when running the setup script to skips some steps or print a help menu.

# Project Issue
<!--
A link to the github project issue
ex: [Create Issue Templates #15](github.com/Senior-Design-0x07/the-hobby-hub/issues/15)
-->
 N/A


# Test Results
<!--
- What was done in order to verify the issue is resolved? 
- Requirements in issue template "verification criteria" is addressed
-->

setup script runs with add different combinations of arguments and ignores non specified arguments (it is robust). 

NOTE: I want someone to try and run this branch and see if the systemd service works for them. in order to tell, run the setup and restart your board. then run the following command:
`sudo journalctl | grep "hobby"` if you don't get any output then it failed and let me know!!


